### PR TITLE
:bug: s/mark/props.mark

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -261,7 +261,7 @@ img {
           >
             {props.mark instanceof URL
               ? <img src={props.mark.href} />
-              : `[${mark}]`}
+              : `[${props.mark}]`}
           </div>
         ))}
       </div>


### PR DESCRIPTION
close [⬜httpsで始まるURLをmarkに指定しても、URLと認識されない (scrapbox-select-suggestion)](https://scrapbox.io/takker/⬜httpsで始まるURLをmarkに指定しても、URLと認識されない_(scrapbox-select-suggestion))