### PR TITLE
:sparkles: scrapbox.Project.nameを常に起動時に有効化するoptionを入れた

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -52,15 +52,25 @@ export interface AppProps {
   projects: string[];
   mark: Record<string, string | URL>;
   hideSelfMark: boolean;
+  enableSelfProjectOnStart: boolean;
 }
 
 export const App = (props: AppProps) => {
-  const { limit, callback, projects, mark, hideSelfMark } = props;
+  const {
+    limit,
+    callback,
+    projects,
+    mark,
+    hideSelfMark,
+    enableSelfProjectOnStart,
+  } = props;
 
   const { text, range } = useSelection();
   const [frag, setFrag] = useFrag(text, range);
   const source = useSource(projects);
-  const { projects: enables, set } = useProjectFilter(projects);
+  const { projects: enables, set } = useProjectFilter(projects, {
+    enableSelfProjectOnStart,
+  });
 
   // 検索
   const [candidates, setCandidates] = useState<

--- a/mod.tsx
+++ b/mod.tsx
@@ -66,16 +66,22 @@ export const setup = (init?: SetupInit): Promise<Operators> => {
     hideSelfMark = true,
     enableSelfProjectOnStart = true,
   } = init ?? {};
-  const projects = init?.projects
+  const projects = (() => {
+    if (!init?.projects || init.projects.length === 0) {
+      return [scrapbox.Project.name];
+    }
+
     // フラグが立っているときのみ、現在projectを補完対象にする
-    ? (enableSelfProjectOnStart
+    const projects = enableSelfProjectOnStart
       ? [scrapbox.Project.name, ...init.projects]
-      : init.projects)
-      // 重複を省く
-      .filter((project, i) =>
-        !init.projects?.some?.((p, j) => j < i && p === project)
-      )
-    : [scrapbox.Project.name];
+      : init.projects;
+
+    // 重複を省く
+    return projects.filter((project, i) =>
+      !init.projects?.some?.((p, j) => j < i && p === project)
+    );
+  })();
+
   setDebugMode(debug);
   return new Promise<Operators>(
     (resolve) =>

--- a/mod.tsx
+++ b/mod.tsx
@@ -78,7 +78,7 @@ export const setup = (init?: SetupInit): Promise<Operators> => {
 
     // 重複を省く
     return projects.filter((project, i) =>
-      !init.projects?.some?.((p, j) => j < i && p === project)
+      !projects.some((p, j) => j < i && p === project)
     );
   })();
 


### PR DESCRIPTION
close [⬜scriptを実行しているprojectのソースを、設定に関わらず無条件で有効にする機能 (scrapbox-select-suggestion)](https://scrapbox.io/takker/⬜scriptを実行しているprojectのソースを、設定に関わらず無条件で有効にする機能_(scrapbox-select-suggestion))