### PR TITLE
:+1: アイコンのproject name及びリンク先のヒントをtooltipで出す

### DIFF
--- a/Candidate.tsx
+++ b/Candidate.tsx
@@ -71,6 +71,7 @@ export const Mark = (
     tabIndex={0}
     href={`../${project}/${encodeTitleURI(title)}`}
     onClick={useConfirm(confirm)}
+    title={`/${project}/${encodeTitleURI(title)}`}
   >
     {mark instanceof URL ? <img src={mark.href} /> : `[${mark}]`}
   </a>

--- a/Completion.tsx
+++ b/Completion.tsx
@@ -228,6 +228,7 @@ export const Completion = (
 const Mark = (
   props: {
     enable: boolean;
+    name: string;
     onClick: h.JSX.MouseEventHandler<HTMLDivElement>;
     mark: URL | string;
   },
@@ -235,6 +236,7 @@ const Mark = (
   <div
     className={props.enable ? "mark" : "mark disabled"}
     onClick={props.onClick}
+    title={props.name}
   >
     {props.mark instanceof URL
       ? <img src={props.mark.href} />


### PR DESCRIPTION
close [⬜.mark imgにtitle属性をつける (scrapbox-select-suggestion)](https://scrapbox.io/takker/⬜.mark_imgにtitle属性をつける_(scrapbox-select-suggestion))