### PR TITLE
:bug: Project絞り込みパネルを押すと、突然ガクガクとスクロールしてしまう

### DIFF
--- a/Completion.tsx
+++ b/Completion.tsx
@@ -17,6 +17,7 @@ import {
   replaceLines,
   Scrapbox,
   takeCursor,
+  textInput,
 } from "./deps/scrapbox.ts";
 import {
   Candidate as CandidateComponent,
@@ -202,9 +203,8 @@ export const Completion = (
           enable: enableProjects.includes(project),
           mark: detectURL(mark[project] ?? "", import.meta.url) || project[0],
           onClick: () => {
-            const cursor = takeCursor();
             set(project, !enableProjects.includes(project));
-            cursor.focus();
+            textInput()!.focus();
           },
         }]
         : []


### PR DESCRIPTION
close [✅project絞り込みパネルを押すと急に上にガクガクとスクロールする (scrapbox-select-suggestion)](https://scrapbox.io/takker/✅project絞り込みパネルを押すと急に上にガクガクとスクロールする_(scrapbox-select-suggestion))