### PR TITLE
:art: project絞り込みパネルのアイコンを4段組みで表示する

### DIFF
--- a/CSS.tsx
+++ b/CSS.tsx
@@ -8,26 +8,26 @@ import { h } from "./deps/preact.tsx";
 export const CSS = () => (
   <style>
     {`.container {
-position: absolute;
-margin-top: 14px;
-max-height: 80vh;
-z-index: 301;
+  position: absolute;
+  margin-top: 14px;
+  max-height: 80vh;
+  z-index: 301;
 
-background-color: var(--select-suggest-bg, #111);
-font-family: var(--select-suggest-font-family, "Open Sans", Helvetica, Arial, "Hiragino Sans", sans-serif);
-color: var(--select-suggest-text-color, #eee);
-border-radius: 4px;
+  background-color: var(--select-suggest-bg, #111);
+  font-family: var(--select-suggest-font-family, "Open Sans", Helvetica, Arial, "Hiragino Sans", sans-serif);
+  color: var(--select-suggest-text-color, #eee);
+  border-radius: 4px;
 }
 .candidates {
-max-width: 80vw;
+  max-width: 80vw;
 }
 .projects {
-max-width: 10vw;
-margin-right: 4px;
-display: grid;
-grid-template-rows: repeat(4, 1fr);
-grid-auto-flow: column;
-     direction: rtl;
+  max-width: 10vw;
+  margin-right: 4px;
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  grid-auto-flow: column;
+  direction: rtl;
 }
 .container.candidates > :not(:first-child) {
   border-top: 1px solid var(--select-suggest-border-color, #eee);
@@ -35,37 +35,37 @@ grid-auto-flow: column;
 .container.candidates > *{
   font-size: 11px;
   line-height: 1.2em;
-padding: 0.5em 10px;
+  padding: 0.5em 10px;
 }
 .candidate {
-display: flex;
+  display: flex;
 }
 a {
-display: block;
-         text-decoration: none;
-color: inherit;
+  display: block;
+  text-decoration: none;
+  color: inherit;
 }
 a:not(.mark) {
-width: 100%;
-  }
+  width: 100%;
+}
 .selected a {
   background-color: var(--select-suggest-selected-bg, #222);
   text-decoration: underline
 }
 img {
-height: 1.3em;
-width: 1.3em;
-position: relative;
-          object-fit: cover;
-          object-position: 0% 0%;
+  height: 1.3em;
+  width: 1.3em;
+  position: relative;
+  object-fit: cover;
+  object-position: 0% 0%;
 }
 .disabled {
-filter: grayscale(1.0) opacity(0.5);
+  filter: grayscale(1.0) opacity(0.5);
 }
 .counter {
-color: var(--select-suggest-information-text-color, #aaa);
-       font-size: 80%;
-       font-style: italic;
+  color: var(--select-suggest-information-text-color, #aaa);
+  font-size: 80%;
+  font-style: italic;
 }`}
   </style>
 );


### PR DESCRIPTION
close [⬜project絞り込みパネルが画面からはみ出そうな時は、n段組みにする](https://scrapbox.io/takker/⬜project絞り込みパネルが画面からはみ出そうな時は、n段組みにする)
thanks to @MijinkoSD and @yuyasurarin for the style fixing

ref. [2022/12/01](https://scrapbox.io/villagepump/2022%2F12%2F01#6387d9801280f00000d4bec0)