### PR TITLE
:recycle: Relaxation limit of candidate type

### DIFF
--- a/Completion.tsx
+++ b/Completion.tsx
@@ -27,7 +27,7 @@ import { SelectInit, useSelect } from "./useSelect.ts";
 import { useSource } from "./useSource.ts";
 import { usePosition } from "./usePosition.ts";
 import { incrementalSearch } from "./incrementalSearch.ts";
-import { sort } from "./search.ts";
+import { makeCompareAse } from "./sort.ts";
 import { useProjectFilter } from "./useProjectFilter.ts";
 import { Action, State } from "./reducer.ts";
 import { logger } from "./debug.ts";
@@ -83,6 +83,7 @@ export const Completion = (
   const [candidates, setCandidates] = useState<
     { title: string; projects: string[] }[]
   >([]);
+  const compareAse = useMemo(() => makeCompareAse(projects), [projects]);
   useEffect(() => {
     if (state !== "completion") {
       setCandidates([]);
@@ -93,15 +94,14 @@ export const Completion = (
       source,
       (candidates) =>
         setCandidates(
-          sort(candidates, projects)
-            .map((page) => ({
-              title: page.title,
-              projects: page.metadata.map(({ project }) => project),
-            })),
+          candidates.sort(compareAse).map((page) => ({
+            title: page.title,
+            projects: page.metadata.map(({ project }) => project),
+          })),
         ),
       { chunk: 5000 },
     );
-  }, [state, source, query]);
+  }, [state, source, query, compareAse]);
 
   /** 補完候補を挿入する函数
    *

--- a/incrementalSearch.ts
+++ b/incrementalSearch.ts
@@ -1,4 +1,5 @@
-import { Candidate, CandidateWithPoint, makeFilter } from "./search.ts";
+import { makeFilter, MatchInfo } from "./search.ts";
+import { Candidate } from "./source.ts";
 import { logger } from "./debug.ts";
 
 export interface IncrementalSearchOptions {
@@ -18,10 +19,10 @@ export interface IncrementalSearchOptions {
 export const incrementalSearch = (
   query: string,
   source: Candidate[],
-  listener: (candidates: CandidateWithPoint[]) => void,
+  listener: (candidates: (Candidate & MatchInfo)[]) => void,
   options?: IncrementalSearchOptions,
 ): () => void => {
-  const filter = makeFilter(query);
+  const filter = makeFilter<Candidate>(query);
   if (!filter) {
     listener([]);
     return () => {};
@@ -29,7 +30,7 @@ export const incrementalSearch = (
 
   let terminate = false;
   let timer: number | undefined;
-  const candidates: CandidateWithPoint[] = [];
+  const candidates: (Candidate & MatchInfo)[] = [];
   const update = () => {
     listener(candidates);
     timer = undefined;

--- a/sort.ts
+++ b/sort.ts
@@ -1,0 +1,46 @@
+import { MatchInfo } from "./search.ts";
+import { Candidate } from "./source.ts";
+
+/** 候補を昇順に比較する函数を作る
+ *
+ * 返り値の意味はArray.prototype.sort()にわたす函数と同じ
+ *
+ * @param projects projectの優先順位付けに使う配列。優先度の高い順にprojectを並べる
+ * @return 昇順に比較する函数
+ */
+export const makeCompareAse = (
+  projects: readonly string[],
+): (a: Candidate & MatchInfo, b: Candidate & MatchInfo) => number => {
+  const projectMap = Object.fromEntries(
+    projects.map((project, i) => [project, i]),
+  );
+
+  return (a, b) => {
+    // 1. 編集距離が短い順
+    const diff = a.dist - b.dist;
+    if (diff !== 0) return diff;
+
+    // 2. マッチ位置が早い順
+    const sa = a.matches.map(([s]) => s).sort();
+    const sb = b.matches.map(([s]) => s).sort();
+    for (let i = 0; i < sa.length; i++) {
+      const sdiff = sa[i] - (sb[i] ?? sb.length);
+      if (sdiff !== 0) return sdiff;
+    }
+
+    // 3. 文字列が短い順
+    const ldiff = a.title.length - b.title.length;
+    if (ldiff !== 0) return ldiff;
+
+    // 4. projectsで若い順
+    const pdiff = Math.min(
+      ...a.metadata.map((meta) => projectMap[meta.project] ?? projects.length),
+    ) - Math.min(
+      ...b.metadata.map((meta) => projectMap[meta.project] ?? projects.length),
+    );
+    if (pdiff !== 0) return pdiff;
+
+    // 5. 更新日時が新しい順
+    return b.updated - a.updated;
+  };
+};

--- a/source.ts
+++ b/source.ts
@@ -1,0 +1,9 @@
+export interface Candidate {
+  title: string;
+  titleLc: string;
+  updated: number;
+  metadata: {
+    project: string;
+    hasIcon: boolean;
+  }[];
+}

--- a/useSource.ts
+++ b/useSource.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "./deps/preact.tsx";
-import { Candidate } from "./search.ts";
 import { checkUpdate, listenUpdate, load, Source } from "./storage.ts";
+import { Candidate } from "./source.ts";
 
 /** 補完ソースを提供するhook */
 export const useSource = (


### PR DESCRIPTION
`makeFilter()`と`sort()`に入れられる型を、指定したpropertiesさえあれば何でも入れられるよう緩和した

[scrapbox-select-suggestionの計算速度調査](https://scrapbox.io/takker/scrapbox-select-suggestionの計算速度調査)で必要になった