### PR TITLE
:art: make buttons larger for mobile

### DIFF
--- a/CSS.tsx
+++ b/CSS.tsx
@@ -15,31 +15,40 @@ export const CSS = () => (
 
   background-color: var(--select-suggest-bg, #111);
   font-family: var(--select-suggest-font-family, "Open Sans", Helvetica, Arial, "Hiragino Sans", sans-serif);
+  font-size: 14px;
   color: var(--select-suggest-text-color, #eee);
   border-radius: 4px;
 }
 .candidates {
   max-width: 80vw;
 }
+.candidates:is(:not([data-os*="android"]), :not([data-os*="ios"])) {
+  font-size:11px;
+
+}
 .projects {
-  max-width: 10vw;
   margin-right: 4px;
   display: grid;
   grid-template-rows: repeat(4, 1fr);
   grid-auto-flow: column;
   direction: rtl;
 }
-.container.candidates > :not(:first-child) {
+.projects:is([data-os*="android"], [data-os*="ios"]) > * {
+  padding: 6px;
+}
+
+.candidates > :not(:first-child) {
   border-top: 1px solid var(--select-suggest-border-color, #eee);
 }
-.container.candidates > *{
-  font-size: 11px;
+.candidates > *{
   line-height: 1.2em;
   padding: 0.5em 10px;
 }
+
 .candidate {
   display: flex;
 }
+
 a {
   display: block;
   text-decoration: none;

--- a/CSS.tsx
+++ b/CSS.tsx
@@ -22,7 +22,7 @@ export const CSS = () => (
 .candidates {
   max-width: 80vw;
 }
-.candidates:is(:not([data-os*="android"]), :not([data-os*="ios"])) {
+.candidates:not([data-os*="android"]):not([data-os*="ios"]) {
   font-size:11px;
 
 }

--- a/Completion.tsx
+++ b/Completion.tsx
@@ -226,6 +226,9 @@ export const Completion = (
     [candidatesProps.length, top, left, state],
   );
 
+  /** UserAgent判定 */
+  const os = useMemo(() => document.documentElement.dataset.os ?? "", []);
+
   /** project絞り込みパネルのスタイル
    *
    * projectが一つしか指定されていなければ表示しない
@@ -244,10 +247,19 @@ export const Completion = (
 
   return (
     <>
-      <div className="container projects" style={projectFilterStyle}>
+      <div
+        className="container projects"
+        data-os={os}
+        style={projectFilterStyle}
+      >
         {projectProps.map((props) => <Mark {...props} />)}
       </div>
-      <div ref={ref} className="container candidates" style={listStyle}>
+      <div
+        ref={ref}
+        className="container candidates"
+        data-os={os}
+        style={listStyle}
+      >
         {candidatesProps.map((props, i) => (
           <CandidateComponent
             key={props.title}


### PR DESCRIPTION
close [⬜mobileで補完候補とproject絞り込みパネルのアイコンを大きくする](https://scrapbox.io/takker/⬜mobileで補完候補とproject絞り込みパネルのアイコンを大きくする)