### PR TITLE
:art: アイテムが4より少ないときは、段数を少なくする

### DIFF
--- a/CSS.tsx
+++ b/CSS.tsx
@@ -29,7 +29,7 @@ export const CSS = () => (
 .projects {
   margin-right: 4px;
   display: grid;
-  grid-template-rows: repeat(4, 1fr);
+  grid-template-rows: repeat(4, min-content);
   grid-auto-flow: column;
   direction: rtl;
 }


### PR DESCRIPTION
fix #31 
see also [✅project絞り込みパネルが画面からはみ出そうな時は、n段組みにする](https://scrapbox.io/takker/✅project絞り込みパネルが画面からはみ出そうな時は、n段組みにする#639854da1280f0000068c37a)

thanks to @MijinkoSD and @yuyasurarin for the style fixing