### PR TITLE
:bug: /を含む任意の文字列をURL扱いしていた

### DIFF
--- a/detectURL.test.ts
+++ b/detectURL.test.ts
@@ -46,6 +46,38 @@ Deno.test("Relative Path", async (t) => {
     });
   }
   {
+    const text = "#editor { display: block; }";
+    await t.step(text, () => {
+      const url = detectURL(text, base);
+      assert(!(url instanceof URL));
+      assertEquals(url, text);
+    });
+  }
+  {
+    const text = "#editor { background: url('../../image.png'); }";
+    await t.step(text, () => {
+      const url = detectURL(text, base);
+      assert(!(url instanceof URL));
+      assertEquals(url, text);
+    });
+  }
+  {
+    const text = "#editor { background: url('./image.png'); }";
+    await t.step(text, () => {
+      const url = detectURL(text, base);
+      assert(!(url instanceof URL));
+      assertEquals(url, text);
+    });
+  }
+  {
+    const text = "#editor { background: url('/image.png'); }";
+    await t.step(text, () => {
+      const url = detectURL(text, base);
+      assert(!(url instanceof URL));
+      assertEquals(url, text);
+    });
+  }
+  {
     const text = "./test.css";
     await t.step(text, () => {
       const url = detectURL(text, base);

--- a/detectURL.ts
+++ b/detectURL.ts
@@ -11,7 +11,7 @@ export const detectURL = (
     if (!base) return text;
     // 相対パスへの変換を試みる
     // ./や../や/で始まらない文字列は、相対パス扱いしない
-    if (!/^\.\/|\.\.\/|\//.test(text)) return text;
+    if (!/^\.\/|^\.\.\/|^\//.test(text)) return text;
     try {
       return new URL(text, base);
     } catch (e: unknown) {


### PR DESCRIPTION
close [⬜detectURLの正規表現を間違えていた](https://scrapbox.io/takker/⬜detectURLの正規表現を間違えていた)
ref https://github.com/takker99/ScrapBubble/pull/112