### PR TITLE
:bug: リンク入力補完時に検索語句を末尾一文字削って検索していた

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -205,7 +205,7 @@ export const App = (props: AppProps) => {
         const cursorLine = scrapbox.Page.lines[line];
         dispatch({
           type: "completionupdate",
-          query: cursorLine.text.slice(pos.start + 1, pos.end - 1),
+          query: cursorLine.text.slice(pos.start + 1, pos.end),
           context: "input",
           range: pos,
           position: { line, char: pos.start },


### PR DESCRIPTION
close [✅bracket内の文字列取得処理がバグっている@2023-01-31](https://scrapbox.io/takker/✅bracket内の文字列取得処理がバグっている@2023-01-31)