### PR TITLE
:boom: 複数のprojectsが設定されたときのみ、候補にアイコンを表示する

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -90,7 +90,6 @@ export interface AppProps {
   projects: string[];
   mark: Record<string, string | URL>;
   style: string | URL;
-  hideSelfMark: boolean;
   enableSelfProjectOnStart: boolean;
 }
 

--- a/Completion.tsx
+++ b/Completion.tsx
@@ -41,7 +41,6 @@ export interface CompletionProps {
   state: State["state"];
   range?: State["range"];
   position?: State["position"];
-  hideSelfMark: boolean;
   enableSelfProjectOnStart: boolean;
   callback: (operators?: Operators) => void;
   mark: Record<string, string | URL>;
@@ -71,7 +70,6 @@ export const Completion = (
     projects,
     dispatch,
     mark,
-    hideSelfMark,
   }: CompletionProps,
 ) => {
   const { projects: enableProjects, set } = useProjectFilter(projects, {
@@ -143,9 +141,10 @@ export const Completion = (
           enableProjects.includes(project)
             ? [{
               name: project,
-              mark: hideSelfMark && project === scrapbox.Project.name
+              mark: project === scrapbox.Project.name && projects.length < 2
                 ? ""
-                : detectURL(mark[project] ?? "", import.meta.url) || project[0],
+                : detectURL(mark[project] ?? "", import.meta.url) ||
+                  project[0],
               confirm: () => confirm(candidate.title, project),
             }]
             : []
@@ -155,7 +154,7 @@ export const Completion = (
     logger.timeEnd("filtering by projects");
 
     return result;
-  }, [enableProjects, candidates, limit, mark, hideSelfMark, confirm]);
+  }, [enableProjects, projects.length, candidates, limit, mark, confirm]);
 
   // 候補選択
   const { selectedIndex, next, prev, selectLast, selectFirst } = useSelect(

--- a/mod.tsx
+++ b/mod.tsx
@@ -35,12 +35,6 @@ export interface SetupInit {
    */
   mark?: Record<string, string | URL>;
 
-  /** 現在ページと同じprojectのアイコンを表示するかどうか
-   *
-   * @default true (表示しない)
-   */
-  hideSelfMark?: boolean;
-
   /** カスタムCSS
    *
    * URL or URL文字列の場合は、CSSファイルへのURLだとみなして<link />で読み込む
@@ -71,7 +65,6 @@ export const setup = (init?: SetupInit): Promise<Operators> => {
     debug = false,
     mark = {},
     style = "",
-    hideSelfMark = true,
     enableSelfProjectOnStart = true,
   } = init ?? {};
   const projects = (() => {
@@ -98,7 +91,6 @@ export const setup = (init?: SetupInit): Promise<Operators> => {
           limit={limit}
           projects={projects}
           mark={mark}
-          hideSelfMark={hideSelfMark}
           style={style}
           callback={resolve}
           enableSelfProjectOnStart={enableSelfProjectOnStart}


### PR DESCRIPTION
close [⬜️複数のprojectを補完候補に入れているときは、現在projectのアイコンを表示する](https://scrapbox.io/takker/⬜️複数のprojectを補完候補に入れているときは、現在projectのアイコンを表示する)