### PR TITLE
:+1: 候補が見つかるまで、前回の検索結果を消さずに表示する

### DIFF
--- a/Completion.tsx
+++ b/Completion.tsx
@@ -92,11 +92,14 @@ export const Completion = (
       query,
       source,
       (candidates) =>
-        setCandidates(
-          candidates.sort(compareAse).map((page) => ({
-            title: page.title,
-            projects: page.metadata.map(({ project }) => project),
-          })),
+        setCandidates((prev) =>
+          // まだ候補が見つからない場合は、前回の検索結果を表示したままにする
+          candidates.length === 0
+            ? prev
+            : candidates.sort(compareAse).map((page) => ({
+              title: page.title,
+              projects: page.metadata.map(({ project }) => project),
+            }))
         ),
       { chunk: 5000 },
     );


### PR DESCRIPTION
close [✅bracket内で入力している間は、補完候補をリセットしない (scrapbox-select-suggestion)](https://scrapbox.io/takker/✅bracket内で入力している間は、補完候補をリセットしない_(scrapbox-select-suggestion))