### PR TITLE
:sparkles: project絞り込みパネルの並び順を関連度順に並び替える

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -82,7 +82,7 @@ export interface AppProps {
   /** 表示する最大候補数 */
   limit: number;
   callback: (operators: Operators) => void;
-  projects: string[];
+  projects: Set<string>;
   mark: Record<string, string | URL>;
   style: string | URL;
   enableSelfProjectOnStart: boolean;

--- a/mod.tsx
+++ b/mod.tsx
@@ -27,7 +27,7 @@ export interface SetupInit {
    *
    * `enableSelfProjectOnStart`を`true`にすると、自動で`scrapbox.Project.name`が追加される
    */
-  projects?: string[];
+  projects?: Iterable<string>;
 
   /** 候補のソース元の識別子に使う文字列もしくはアイコンのURL
    *
@@ -67,21 +67,10 @@ export const setup = (init?: SetupInit): Promise<Operators> => {
     style = "",
     enableSelfProjectOnStart = true,
   } = init ?? {};
-  const projects = (() => {
-    if (!init?.projects || init.projects.length === 0) {
-      return [scrapbox.Project.name];
-    }
-
-    // フラグが立っているときのみ、現在projectを補完対象にする
-    const projects = enableSelfProjectOnStart
-      ? [scrapbox.Project.name, ...init.projects]
-      : init.projects;
-
-    // 重複を省く
-    return projects.filter((project, i) =>
-      !projects.some((p, j) => j < i && p === project)
-    );
-  })();
+  const projects = new Set([
+    ...(enableSelfProjectOnStart ? [scrapbox.Project.name] : []),
+    ...(init?.projects ?? [scrapbox.Project.name]),
+  ]);
 
   setDebugMode(debug);
   return new Promise<Operators>(

--- a/sort.ts
+++ b/sort.ts
@@ -8,39 +8,26 @@ import { Candidate } from "./source.ts";
  * @param projects projectの優先順位付けに使う配列。優先度の高い順にprojectを並べる
  * @return 昇順に比較する函数
  */
-export const makeCompareAse = (
-  projects: readonly string[],
-): (a: Candidate & MatchInfo, b: Candidate & MatchInfo) => number => {
-  const projectMap = Object.fromEntries(
-    projects.map((project, i) => [project, i]),
-  );
+export const compareAse = (
+  a: Candidate & MatchInfo,
+  b: Candidate & MatchInfo,
+): number => {
+  // 1. 編集距離が短い順
+  const diff = a.dist - b.dist;
+  if (diff !== 0) return diff;
 
-  return (a, b) => {
-    // 1. 編集距離が短い順
-    const diff = a.dist - b.dist;
-    if (diff !== 0) return diff;
+  // 2. マッチ位置が早い順
+  const sa = a.matches.map(([s]) => s).sort();
+  const sb = b.matches.map(([s]) => s).sort();
+  for (let i = 0; i < sa.length; i++) {
+    const sdiff = sa[i] - (sb[i] ?? sb.length);
+    if (sdiff !== 0) return sdiff;
+  }
 
-    // 2. マッチ位置が早い順
-    const sa = a.matches.map(([s]) => s).sort();
-    const sb = b.matches.map(([s]) => s).sort();
-    for (let i = 0; i < sa.length; i++) {
-      const sdiff = sa[i] - (sb[i] ?? sb.length);
-      if (sdiff !== 0) return sdiff;
-    }
+  // 3. 文字列が短い順
+  const ldiff = a.title.length - b.title.length;
+  if (ldiff !== 0) return ldiff;
 
-    // 3. 文字列が短い順
-    const ldiff = a.title.length - b.title.length;
-    if (ldiff !== 0) return ldiff;
-
-    // 4. projectsで若い順
-    const pdiff = Math.min(
-      ...a.metadata.map((meta) => projectMap[meta.project] ?? projects.length),
-    ) - Math.min(
-      ...b.metadata.map((meta) => projectMap[meta.project] ?? projects.length),
-    );
-    if (pdiff !== 0) return pdiff;
-
-    // 5. 更新日時が新しい順
-    return b.updated - a.updated;
-  };
+  // 4. 更新日時が新しい順
+  return b.updated - a.updated;
 };

--- a/useProjectFilter.ts
+++ b/useProjectFilter.ts
@@ -23,22 +23,22 @@ interface UseProjectFilterResult {
  * @return 検索対象のprojectsのリスト
  */
 export const useProjectFilter = (
-  projects: string[],
+  projects: Iterable<string>,
   options: useProjectFilterOptions,
 ): UseProjectFilterResult => {
   const [enableProjects, setEnableProjects] = useState(
-    getEnables(projects, options),
+    getEnables([...projects], options),
   );
   const set = useCallback((project: string, flag: boolean) => {
     setFrag(project, flag, projects, options);
-    setEnableProjects(getEnables(projects, options));
+    setEnableProjects(getEnables([...projects], options));
   }, [projects, options.enableSelfProjectOnStart]);
 
   //更新通知を受け取る
   useEffect(() => {
     const listener = (e: StorageEvent) => {
       if (e.key !== key) return;
-      setEnableProjects(getEnables(projects, options));
+      setEnableProjects(getEnables([...projects], options));
     };
     addEventListener("storage", listener);
     return () => removeEventListener("storage", listener);
@@ -91,10 +91,10 @@ const getEnables = (
 const setFrag = (
   project: string,
   flag: boolean,
-  init: string[],
+  init: Iterable<string>,
   options: useProjectFilterOptions,
 ): void => {
-  const old = getEnables(init, options);
+  const old = getEnables([...init], options);
   if (options.enableSelfProjectOnStart && project === scrapbox.Project.name) {
     enableSelfProject = flag;
   }


### PR DESCRIPTION
close [✅project絞り込みパネルに表示するprojectの順番を、より正確にマッチしたリンクが多い順に並び替える](https://scrapbox.io/takker/✅project絞り込みパネルに表示するprojectの順番を、より正確にマッチしたリンクが多い順に並び替える)