### PR TITLE
:+1: project scoreをdata属性に入れる

### DIFF
--- a/Completion.tsx
+++ b/Completion.tsx
@@ -160,6 +160,7 @@ export const Completion = (
           name: project,
           enable: enableProjects.includes(project),
           mark: detectURL(mark[project] ?? "", import.meta.url) || project[0],
+          score: projectScore.get(project)!,
           onClick: () =>
             freezeUntil(() => {
               set(project, !enableProjects.includes(project));
@@ -240,12 +241,14 @@ const Mark = (
   props: {
     enable: boolean;
     name: string;
+    score: number;
     onClick: h.JSX.MouseEventHandler<HTMLDivElement>;
     mark: URL | string;
   },
 ) => (
   <div
     className={props.enable ? "mark" : "mark disabled"}
+    data-score={props.score.toPrecision(3)}
     onClick={props.onClick}
     title={props.name}
   >


### PR DESCRIPTION
@MijinkoSD
>自分は他のプロジェクトを追加してないからあれだけど、より意味のある並びになって楽しそうに見える
>じゃあ、次は1番言及が多いプロジェクトを100%として、言及数の割合でアイコンの枠線の色が変わるようにしましょ…（ﾆﾁｬｱ）
>（無茶振り）

@takker99 
>CSS selectorまでは振れるかな
>スタイル付けは任せた(無茶振り返し)

@MijinkoSD
>多分、style属性を加えて、
> ```
> 100%: border: 2px solid #0f4;
> 0%: border: 2px solid #f04;
> ```
>と
>```
>border-radius: 2px;
>```
>をつける感じにすれば良さそう
>px数はお好みで
>ただ、自分で言っておいてなんだけど、今のスタイルだと結構アイコンがぎゅうぎゅうだから、
>`border-radius`までつけると情報量が多くなりすぎてしまいそう
>単純にアイコンの周りに若干のマージンを取って、背景色を変えるぐらいが無難かな…

という話をDiscordでしてて、ノリで実装しました。

見ての通り、ちょっとpropertyを渡すだけで済みました