### PR TITLE
:+1: 検索結果を一定間隔ごとに表示する。代わりに進捗率をリアルタイムで表示する

### DIFF
--- a/CSS.tsx
+++ b/CSS.tsx
@@ -75,6 +75,12 @@ img {
   color: var(--select-suggest-information-text-color, #aaa);
   font-size: 80%;
   font-style: italic;
+}
+.progress[style] {
+  padding: unset;
+  border: unset;
+  height: 0.5px;
+  transition: background 0.1s;
 }`}
   </style>
 );

--- a/Completion.tsx
+++ b/Completion.tsx
@@ -72,7 +72,7 @@ export const Completion = (
   });
 
   /** 検索結果 */
-  const { projectScore, items } = useSearch(
+  const { projectScore, items, progress } = useSearch(
     context === "input" ? query.slice(1, -1) : query,
     source,
   );
@@ -235,6 +235,12 @@ export const Completion = (
             {`${items.length - limit} more links`}
           </div>
         )}
+        <div
+          className="progress"
+          style={`background:  linear-gradient(to right, var(--select-suggest-border-color, #eee) ${
+            (progress * 100).toPrecision(3)
+          }%, transparent ${(progress * 100).toPrecision(3)}%)`}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
#76 の続き
close [⬜検索の進捗状況を出す (scrapbox-select-suggestion)](https://scrapbox.io/takker/⬜検索の進捗状況を出す_(scrapbox-select-suggestion))