### PR TITLE
:bug: ソース更新時の再検索で、中断処理を挟んでいなかった

### DIFF
--- a/useSearch.ts
+++ b/useSearch.ts
@@ -57,6 +57,7 @@ export const useSearch = (
       // ソース更新をトリガーにした再検索は、すべて検索し終わってから返す
       if (state.type === "source") {
         for await (const [candidates] of iterator) {
+          if (terminate) return;
           stack.push(...candidates);
         }
         setProgress(1.0);


### PR DESCRIPTION
close [⬜️ソース更新時の再検索に中断処理をいれ忘れてた (scrapbox-select-suggestion)](https://scrapbox.io/takker/⬜️ソース更新時の再検索に中断処理をいれ忘れてた_(scrapbox-select-suggestion))