### PR TITLE
:bug: 補完確定後にfocusが外れていた

### DIFF
--- a/useLifecycle.ts
+++ b/useLifecycle.ts
@@ -143,6 +143,7 @@ export const useLifecycle = (): UseLifecycleResult => {
       });
       await insertText(text);
       cursor.setPosition(position);
+      cursor.focus();
       dispatch({ type: "unlock" });
       dispatch({ type: "cancel" });
     },


### PR DESCRIPTION
close [クリックしてリンクを補完したあとにカーソルが外れてしまう-@2023-09-18](https://scrapbox.io/takker/クリックしてリンクを補完したあとにカーソルが外れてしまう-@2023-09-18)