### PR TITLE
refactor: Use `SharedWorker` only

### DIFF
--- a/Candidate.tsx
+++ b/Candidate.tsx
@@ -1,7 +1,7 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource npm:preact@10 */
 import type { ConfirmInit } from "./Completion.tsx";
-import { type h, useCallback } from "./deps/preact.tsx";
+import { type TargetedMouseEvent, useCallback } from "./deps/preact.tsx";
 import { encodeTitleURI } from "./deps/scrapbox-title.ts";
 
 export interface CandidateProps {
@@ -81,7 +81,7 @@ export const Mark = (
 /** 修飾キーが押されていないときのみ確定する event handlerを作るhook */
 const useConfirm = (confirm: () => void) =>
   useCallback(
-    (e: h.JSX.TargetedMouseEvent<HTMLAnchorElement>) => {
+    (e: TargetedMouseEvent<HTMLAnchorElement>) => {
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       e.preventDefault();
       e.stopPropagation();

--- a/Completion.tsx
+++ b/Completion.tsx
@@ -1,8 +1,9 @@
 /** @jsxRuntime automatic */
 /** @jsxImportSource npm:preact@10 */
 import {
+  type CSSProperties,
   type FunctionComponent,
-  type h,
+  type MouseEventHandler,
   type RefCallback,
   useCallback,
   useEffect,
@@ -137,7 +138,7 @@ export const Completion: FunctionComponent<CompletionProps> = (
 
 interface ItemListProps extends
   Pick<
-    CompletionProps & SearchResult & h.JSX.CSSProperties,
+    CompletionProps & SearchResult & CSSProperties,
     | "start"
     | "confirmAfter"
     | "cancel"
@@ -274,7 +275,7 @@ const ItemList = (
   ]);
 
   /** 補完windowのスタイル */
-  const style = useMemo<h.JSX.CSSProperties>(
+  const style = useMemo<CSSProperties>(
     () =>
       // undefinedとnullをまとめて判定したいので、厳密比較!==は使わない
       candidatesProps.length > 0 && top != null &&
@@ -334,7 +335,7 @@ interface SourceFilterProps extends
   Pick<
     & CompletionProps
     & SearchResult
-    & h.JSX.CSSProperties
+    & CSSProperties
     & UseProjectFilterResult,
     | "mark"
     | "top"
@@ -390,7 +391,7 @@ const SourceFilter = (
    *
    * 非表示の検索候補があれば表示し続ける
    */
-  const style = useMemo<h.JSX.CSSProperties>(
+  const style = useMemo<CSSProperties>(
     () =>
       // undefinedとnullをまとめて判定したいので、厳密比較!==は使わない
       itemCount > 0 && top != null &&
@@ -417,7 +418,7 @@ const Mark = (
     enable: boolean;
     name: string;
     score: number;
-    onClick: h.JSX.MouseEventHandler<HTMLDivElement>;
+    onClick: MouseEventHandler<HTMLDivElement>;
     mark: URL | string;
   },
 ) => (

--- a/deno.lock
+++ b/deno.lock
@@ -6,20 +6,20 @@
     "jsr:@cosense/std@~0.29.3": "0.29.16",
     "jsr:@cosense/types@0.10": "0.10.10",
     "jsr:@cosense/types@~0.10.4": "0.10.10",
-    "jsr:@std/assert@1": "1.0.14",
-    "jsr:@std/assert@^1.0.13": "1.0.14",
-    "jsr:@std/async@1": "1.0.14",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1": "1.3.0",
     "jsr:@std/encoding@1": "1.0.10",
-    "jsr:@std/fs@^1.0.19": "1.0.19",
-    "jsr:@std/internal@^1.0.10": "1.0.10",
-    "jsr:@std/path@^1.1.1": "1.1.2",
-    "jsr:@std/testing@1": "1.0.15",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
+    "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/testing@1": "1.0.18",
     "jsr:@takker/cosense-storage@0.3": "0.3.4",
     "jsr:@takker/debug-js@0.1": "0.1.2",
     "jsr:@takker/md5@0.1": "0.1.0",
     "jsr:@takker/throttle@0.3": "0.3.1",
     "npm:@logtape/logtape@0.8": "0.8.2",
-    "npm:@okikio/sharedworker@1": "1.1.0",
     "npm:comlink@4": "4.4.2",
     "npm:date-fns@4": "4.1.0",
     "npm:idb@8": "8.0.3",
@@ -27,7 +27,7 @@
     "npm:option-t@51": "51.1.1",
     "npm:option-t@^49.1.0": "49.3.0",
     "npm:option-t@^50.0.2": "50.0.2",
-    "npm:preact@10": "10.27.0"
+    "npm:preact@10": "10.28.4"
   },
   "jsr": {
     "@core/unknownutil@4.3.0": {
@@ -57,39 +57,39 @@
     "@cosense/types@0.10.10": {
       "integrity": "16575916902f22a7d401edbd2305324cfcb378aa2bc39a4fef7ba81a1c84a0a1"
     },
-    "@std/assert@1.0.14": {
-      "integrity": "68d0d4a43b365abc927f45a9b85c639ea18a9fab96ad92281e493e4ed84abaa4",
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/async@1.0.14": {
-      "integrity": "62e954a418652c704d37563a3e54a37d4cf0268a9dcaeac1660cc652880b5326"
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
     },
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
-    "@std/fs@1.0.19": {
-      "integrity": "051968c2b1eae4d2ea9f79a08a3845740ef6af10356aff43d3e2ef11ed09fb06",
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
         "jsr:@std/path"
       ]
     },
-    "@std/internal@1.0.10": {
-      "integrity": "e3be62ce42cab0e177c27698e5d9800122f67b766a0bea6ca4867886cbde8cf7"
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
-    "@std/path@1.1.2": {
-      "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
-    "@std/testing@1.0.15": {
-      "integrity": "a490169f5ccb0f3ae9c94fbc69d2cd43603f2cffb41713a85f99bbb0e3087cbc",
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
       "dependencies": [
-        "jsr:@std/assert@^1.0.13",
+        "jsr:@std/assert@^1.0.19",
         "jsr:@std/fs",
-        "jsr:@std/internal",
+        "jsr:@std/internal@^1.0.13",
         "jsr:@std/path"
       ]
     },
@@ -118,9 +118,6 @@
     "@logtape/logtape@0.8.2": {
       "integrity": "sha512-KikaMHi64p0BHYrYOE2Lom4dOE3R8PGT+21QJ5Ql/SWy0CNOp69dkAlG9RXzENQ6PAMWtiU+4kelJYNvfUvHOQ=="
     },
-    "@okikio/sharedworker@1.1.0": {
-      "integrity": "sha512-Xj9TUWll9mhARsKu5DtlQCjRekfJfQ2E291ow6gmXIz+WuF6uJMH8ZmGhdRTx/ndOippHnm1j/vxXNjmR6JuXw=="
-    },
     "comlink@4.4.2": {
       "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g=="
     },
@@ -139,8 +136,8 @@
     "option-t@51.1.1": {
       "integrity": "sha512-Ww13j9NVqnGpxsaSr1y0o35Xq1WcopAeJkAbk9DWlKRBgFKYLuJwEU1GzWUtkhBhRQY0st5kfdtT02JO6YqEEw=="
     },
-    "preact@10.27.0": {
-      "integrity": "sha512-/DTYoB6mwwgPytiqQTh/7SFRL98ZdiD8Sk8zIUVOxtwq4oWcwrcd1uno9fE/zZmUaUrFNYzbH14CPebOz9tZQw=="
+    "preact@10.28.4": {
+      "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="
     }
   }
 }

--- a/deps/preact.tsx
+++ b/deps/preact.tsx
@@ -1,11 +1,14 @@
 export {
   type ComponentChildren,
+  type CSSProperties,
   Fragment,
   type FunctionComponent,
   h,
+  type MouseEventHandler,
   type Ref,
   type RefCallback,
   render,
+  type TargetedMouseEvent,
   toChildArray,
 } from "npm:preact@10";
 export * from "npm:preact@10/hooks";

--- a/deps/sharedworker.ts
+++ b/deps/sharedworker.ts
@@ -1,1 +1,0 @@
-export * from "npm:@okikio/sharedworker@1";

--- a/reducer.test.ts
+++ b/reducer.test.ts
@@ -44,7 +44,7 @@ const inputEvent = (
   range: Range,
 ): Action => ({
   type: "lines:changed",
-  lines: (lines as Line[]),
+  lines: lines as Line[],
   position,
   range,
 });
@@ -53,7 +53,7 @@ const selectEvent = (
   range: Range,
 ): Action => ({
   type: "selection:changed",
-  lines: (lines as Line[]),
+  lines: lines as Line[],
   position,
   range,
 });
@@ -62,7 +62,7 @@ const cursorEvent = (
   range: Range,
 ): Action => ({
   type: "cursor:changed",
-  lines: (lines as Line[]),
+  lines: lines as Line[],
   position,
   range,
 });
@@ -261,7 +261,7 @@ Deno.test("reducer()", async (t) => {
           assertEquals(
             reducer(disabledAuto, {
               type,
-              lines: (lines as Line[]),
+              lines: lines as Line[],
               position: { line: 6, char: 30 },
               range: emptyRange,
             }),
@@ -310,7 +310,7 @@ Deno.test("reducer()", async (t) => {
             assertEquals(
               reducer(state, {
                 type,
-                lines: (lines as Line[]),
+                lines: lines as Line[],
                 position,
                 range: { start, end },
               }),
@@ -319,7 +319,7 @@ Deno.test("reducer()", async (t) => {
             assertEquals(
               reducer(state, {
                 type,
-                lines: (lines as Line[]),
+                lines: lines as Line[],
                 position,
                 range: { start: end, end: start },
               }),
@@ -353,7 +353,7 @@ Deno.test("reducer()", async (t) => {
             assertEquals(
               reducer(state, {
                 type,
-                lines: (lines as Line[]),
+                lines: lines as Line[],
                 position,
                 range: { start, end },
               }),
@@ -362,7 +362,7 @@ Deno.test("reducer()", async (t) => {
             assertEquals(
               reducer(state, {
                 type,
-                lines: (lines as Line[]),
+                lines: lines as Line[],
                 position,
                 range: { start: end, end: start },
               }),
@@ -398,7 +398,7 @@ Deno.test("reducer()", async (t) => {
               assertEquals(
                 reducer(state, {
                   type,
-                  lines: (lines as Line[]),
+                  lines: lines as Line[],
                   position,
                   range,
                 }),
@@ -473,7 +473,7 @@ Deno.test("reducer()", async (t) => {
         assertEquals(
           reducer(selectCancel, {
             type,
-            lines: (lines as Line[]),
+            lines: lines as Line[],
             position,
             range: {
               start: { line: 6, char: 4 },
@@ -485,7 +485,7 @@ Deno.test("reducer()", async (t) => {
         assertEquals(
           reducer(selectCancel, {
             type,
-            lines: (lines as Line[]),
+            lines: lines as Line[],
             position,
             range: {
               start: { line: 6, char: 4 },
@@ -508,7 +508,7 @@ Deno.test("reducer()", async (t) => {
         assertEquals(
           reducer(selectCancel, {
             type,
-            lines: (lines as Line[]),
+            lines: lines as Line[],
             position: { line: 6, char: 14 },
             range: emptyRange,
           }),
@@ -530,7 +530,7 @@ Deno.test("reducer()", async (t) => {
   await t.step("auto disabled -> ready when lines appear", () => {
     const next = reducer({ type: "disabled" }, {
       type: "cursor:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: emptyRange.start,
       range: emptyRange,
     });
@@ -551,7 +551,7 @@ Deno.test("reducer()", async (t) => {
   await t.step("completion -> cancel -> cancelled", () => {
     const completion = reducer({ type: "ready" }, {
       type: "lines:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: { line: 6, char: 30 },
       range: emptyRange,
     });
@@ -567,7 +567,7 @@ Deno.test("reducer()", async (t) => {
   await t.step("cancelled input blocks re-entry inside link", () => {
     const completion = reducer({ type: "ready" }, {
       type: "lines:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: { line: 6, char: 30 },
       range: emptyRange,
     });
@@ -577,7 +577,7 @@ Deno.test("reducer()", async (t) => {
     const cancelled = reducer(completion, { type: "cancel" });
     const again = reducer(cancelled, {
       type: "cursor:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: { line: 6, char: 31 },
       range: emptyRange,
     });
@@ -587,7 +587,7 @@ Deno.test("reducer()", async (t) => {
   await t.step("selection mode suppressed when cancelled", () => {
     const completion = reducer({ type: "ready" }, {
       type: "lines:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: { line: 6, char: 30 },
       range: emptyRange,
     });
@@ -597,7 +597,7 @@ Deno.test("reducer()", async (t) => {
     const cancelled = reducer(completion, { type: "cancel" });
     const sel = reducer(cancelled, {
       type: "selection:changed",
-      lines: (lines as Line[]),
+      lines: lines as Line[],
       position: { line: 6, char: 31 },
       range: { start: { line: 6, char: 30 }, end: { line: 6, char: 35 } },
     });

--- a/usePosition.ts
+++ b/usePosition.ts
@@ -1,17 +1,17 @@
-import { type h, useMemo, useState } from "./deps/preact.tsx";
+import { type CSSProperties, useMemo, useState } from "./deps/preact.tsx";
 import { getCharDOM, type Position } from "./deps/scrapbox.ts";
 
 /** 補完リストの表示位置を計算するhook */
 export const usePosition = (
   pos: Position,
-): Pick<h.JSX.CSSProperties, "top" | "left" | "right"> & {
+): Pick<CSSProperties, "top" | "left" | "right"> & {
   updateStandardElement: (element: Element | null) => void;
 } => {
   const [standardElement, updateStandardElement] = useState<Element | null>(
     null,
   );
 
-  const style = useMemo<Pick<h.JSX.CSSProperties, "top" | "left">>(() => {
+  const style = useMemo<Pick<CSSProperties, "top" | "left">>(() => {
     /** 基準座標 */
     const parentRect = standardElement?.getBoundingClientRect?.();
     /** 合わせたいDOMの座標 */

--- a/useSearch.ts
+++ b/useSearch.ts
@@ -6,7 +6,6 @@ import { makeCancelableSearch } from "./cancelableSearch.ts";
 import { throttle } from "./deps/throttle.ts";
 import { createDebug } from "./deps/debug.ts";
 import { type Action, createReducer, isSearching } from "./search-state.ts";
-import { SharedWorkerSupported } from "./deps/sharedworker.ts";
 
 const logger = createDebug("scrapbox-select-suggestion:useSearch.ts");
 
@@ -54,9 +53,7 @@ export const useSearch = (
   const search = useMemo(
     () =>
       makeCancelableSearch(
-        SharedWorkerSupported
-          ? new SharedWorker(options.workerUrl, { type: "module" }).port
-          : new Worker(options.workerUrl, { type: "module" }),
+        new SharedWorker(options.workerUrl, { type: "module" }).port,
       ),
     [options.workerUrl],
   );

--- a/worker/search.worker.ts
+++ b/worker/search.worker.ts
@@ -76,18 +76,7 @@ const searchWorkerAPI: SearchWorkerAPI = {
   },
 };
 
-const isSharedWorkerGlobalScope = (
-  scope: unknown,
-): scope is SharedWorkerGlobalScope =>
-  typeof scope === "object" && !!scope && "SharedWorkerGlobalScope" in scope;
-
-if (isSharedWorkerGlobalScope(self)) {
-  // SharedWorker mode
-  (self as SharedWorkerGlobalScope).addEventListener(
-    "connect",
-    (event) => expose(searchWorkerAPI, event.ports[0]),
-  );
-} else {
-  // Regular Worker mode
-  expose(searchWorkerAPI);
-}
+(self as unknown as SharedWorkerGlobalScope).addEventListener(
+  "connect",
+  (event) => expose(searchWorkerAPI, event.ports[0]),
+);


### PR DESCRIPTION
v148からChrome Androidでも`SharedWorker`を使えるようになったので、`Worker`へのfallbackを削除する